### PR TITLE
jest config fix: ignore .cjs files in node_modules

### DIFF
--- a/config/jest.js
+++ b/config/jest.js
@@ -38,7 +38,7 @@ module.exports = (resolve, rootDir) => {
       ),
     },
     transformIgnorePatterns: [
-      '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$',
+      '[/\\\\]node_modules[/\\\\].+\\.(cjs|js|jsx|ts|tsx)$',
       '^.+\\.module\\.(css|sass|scss)$',
     ],
     modulePaths: [],


### PR DESCRIPTION
This fixes the vague `TypeError: (0 , _web.template) is not a function` error when running jest. This happens since solid-js version 0.22.7 which changed output file names from `.cjs.js` to `.cjs`.